### PR TITLE
Fix colore dei link della navbar nell'hover

### DIFF
--- a/sito/assets/static/style.css
+++ b/sito/assets/static/style.css
@@ -286,7 +286,7 @@ header div.latest-news a:hover {
 
 .main-menu .nav li a:hover,
 .main-menu .nav li.active a {
-    color      : #828F41;
+    color      : rgba(255,255,255,0.5);
     background : transparent;
     }
 


### PR DESCRIPTION
Attualmente, il colore dei link della navbar quando ci passi sopra è un verdognolo che è inguardabile (e illeggibile soprattutto):

![schermata 2017-10-16 19 11 25](https://user-images.githubusercontent.com/2299951/31625374-29e8f0c4-b2a6-11e7-9876-1409e9760ba2.png)

La pull request cambia il colore in un più carino `rgba(255, 255, 255, 0.5)`:

![schermata 2017-10-16 19 12 04](https://user-images.githubusercontent.com/2299951/31625383-381b419c-b2a6-11e7-8f0e-77735f9767f9.png)

Che ne pensi?
