### PR TITLE
OpenData meno tech e OpenStreetMap più riuso 

### DIFF
--- a/sito/content/c4p/contents.lr
+++ b/sito/content/c4p/contents.lr
@@ -66,13 +66,13 @@ body:
             <div class="col-md-4">
                 <h4>Open Data</h4>
                 <p>
-                    Software per raccolta ed analisi di dati, basi dati di interesse, esperienze con l'uso o la creazione di dataset.
+                    Esperienze di successo e insuccesso con gli Open Data. Stato dell'arte. Misurazione di ciò che accade. Laboratori di riuso per liberare i dati. FOIA e accesso civico. Dati come bene comune.
                 </p>
             </div>
             <div class="col-md-4">
                 <h4>OpenStreetMap</h4>
                 <p>
-                    Dati geografici liberi e relativi software applicativi per la loro analisi e visualizzazione, esperienze di mapping.
+                    Esperienze di successo con OpenStreetMap. Esempi importanti di riuso dei dati di OpenStreetMap. Strumenti per partecipare al progetto, migliorare i dati e giocare. Progetti che stimolano la creatività.
                 </p>
             </div>
             <p class="clearfix">&nbsp;</p>


### PR DESCRIPTION
Chiariti entrambi gli ambiti per renderli più inclusivi: non solo per sviluppatori, ma anche per attivisti e persone che non sono per forza sviluppatori/sistemisti.